### PR TITLE
add build requirements

### DIFF
--- a/Locale-CLDR/Build.PL
+++ b/Locale-CLDR/Build.PL
@@ -17,11 +17,13 @@ my $builder = Module::Build->new(
     dist_author         => q{John Imrie <j.imrie1@.virginmedia.com>},
     dist_version_from   => 'lib/Locale/CLDR.pm',
     build_requires => {
+        'ok'                => 0,
         'Archive::Extract'  => '0.58',
         'Archive::Zip'      => '1.30',
         'File::Spec'        => '3.33',
         'FindBin'           => '1.50',
         'LWP'               => '6.03',
+        'Test::Exception'   => 0,
         'Test::More'        => '0.98',
     },
     add_to_cleanup      => [ 'Locale-CLDR-*' ],


### PR DESCRIPTION
The testing requirements `ok` and `Test::Exception` were missing from `Build.PL`.
