### PR TITLE
Fix warning in plural rules where fraction is used

### DIFF
--- a/Locale-CLDR/mkcldr.pl
+++ b/Locale-CLDR/mkcldr.pl
@@ -4639,6 +4639,7 @@ sub process_plurals {
 				my $t = length $f ? $f + 0 : '';
 				my $v = length $f;
 				my $w = length $t;
+				$f ||= 0;
 				$t ||= 0;
 
 EOT


### PR DESCRIPTION
There are two languages, Lithuanian (lt) and Sinhala (si), which rely on the fraction part with leading zeros (f) for evaluating plural rules. At the time of evaluation, this part has to be a number and cannot be an empty string, which it currently is if the input is integer.