### PR TITLE
Minor 0.34.1 release

### DIFF
--- a/Locale-CLDR/Changes
+++ b/Locale-CLDR/Changes
@@ -173,3 +173,7 @@ All dates are in ISO 8601 Format
     Tidied documentation
     Restrict 'contained' regions to geographical regions (ignore political regions)
 
+0.34.1 2021-04-11
+    Fixed for-cash rounding problem
+    Fix warning in plural rules where fraction is used
+    Fix typo in POD documentation

--- a/Locale-CLDR/lib/Locale/CLDR.pm
+++ b/Locale-CLDR/lib/Locale/CLDR.pm
@@ -8,7 +8,7 @@ Locale::CLDR - A Module to create locale objects with localisation data from the
 
 =head1 VERSION
 
-Version 0.34
+Version 0.34.1
 
 =head1 SYNOPSIS
 
@@ -39,7 +39,7 @@ or
 
 use v5.10.1;
 use version;
-our $VERSION = version->declare('v0.34');
+our $VERSION = version->declare('v0.34.1');
 
 use open ':encoding(utf8)';
 use utf8;

--- a/Locale-CLDR/mkcldr.pl
+++ b/Locale-CLDR/mkcldr.pl
@@ -39,7 +39,7 @@ $verbose = 1 if grep /-v/, @ARGV;
 use version;
 my $API_VERSION = 0; # This will get bumped if a release is not backwards compatible with the previous release
 my $CLDR_VERSION = '34'; # This needs to match the revision number of the CLDR revision being generated against
-my $REVISION = 0; # This is the build number against the CLDR revision
+my $REVISION = 1; # This is the build number against the CLDR revision
 my $TRIAL_REVISION = ''; # This is the trial revision for unstable releases. Set to '' for the first trial release after that start counting from 1
 our $VERSION = version->parse(join '.', $API_VERSION, ($CLDR_VERSION=~s/^([^.]+).*/$1/r), $REVISION);
 my $CLDR_PATH = $CLDR_VERSION;

--- a/Locale-CLDR/mkcldr.pl
+++ b/Locale-CLDR/mkcldr.pl
@@ -3384,29 +3384,43 @@ has 'day_period_data' => (
 \t\tSWITCH:
 \t\tfor (\$type) {
 EOT
-        foreach my $ctype (keys  %{$calendars{day_period_data}}) {
+        foreach my $ctype (sort keys %{$calendars{day_period_data}}) {
             say $file "\t\t\tif (\$_ eq '$ctype') {";
-			foreach my $day_period_type (keys  %{$calendars{day_period_data}{$ctype}}) {
+			foreach my $day_period_type (sort keys %{$calendars{day_period_data}{$ctype}}) {
 				say $file "\t\t\t\tif(\$day_period_type eq '$day_period_type') {";
-				foreach my $type (sort
-					{ 
-						my $return = 0; 
-						$return = -1 if $a eq 'noon' || $a eq 'midnight';
-						$return = 1 if $b eq 'noon' || $b eq 'midnight';
-						return $return;
-					} keys  %{$calendars{day_period_data}{$ctype}{$day_period_type}}) {
-					# Sort 'at' periods to the top of the list so they are printed first
+                my %type_boundries;
+                my @type_with_boundry_at;
+                my @type_without_boundry_at;
+				foreach my $type (keys %{$calendars{day_period_data}{$ctype}{$day_period_type}}) {
 					my %boundries = map {@$_} @{$calendars{day_period_data}{$ctype}{$day_period_type}{$type}};
 					if (exists $boundries{at}) {
-						my ($hm) = $boundries{at};
+                        push @type_with_boundry_at, $type;
+                    } else {
+                        push @type_without_boundry_at, $type;
+                    }
+                    $type_boundries{$type} = \%boundries;
+                }
+
+                # Sort 'at' periods to the top of the list so they are printed first,
+                # as they compare with an absolute value that might be inside a range
+                # for other types
+                my @sorted = (
+                    (sort @type_with_boundry_at),
+                    (sort @type_without_boundry_at),
+                );
+
+				foreach my $type (@sorted) {
+					my $boundries = $type_boundries{$type};
+					if (exists $boundries->{at}) {
+						my ($hm) = $boundries->{at};
 						$hm =~ s/://;
 						$hm = $hm + 0;
 						say $file "\t\t\t\t\treturn '$type' if \$time == $hm;";
 						next;
 					}
 
-					my $stime = $boundries{from};
-					my $etime = $boundries{before};
+					my $stime = $boundries->{from};
+					my $etime = $boundries->{before};
 
 					foreach ($stime, $etime) {
 						s/://;
@@ -3466,7 +3480,7 @@ EOT
 					next;
 				}
 				
-                foreach my $width (keys %{$calendars{day_periods}{$ctype}{$type}}) {
+                foreach my $width (sort keys %{$calendars{day_periods}{$ctype}{$type}}) {
                     say $file "\t\t\t\t'$width' => {";
 					if (exists $calendars{day_periods}{$ctype}{$type}{$width}{alias}) {
 						say $file "\t\t\t\t\t'alias' => {";
@@ -3477,7 +3491,7 @@ EOT
 						next;
 					}
 				
-                    foreach my $period (keys %{$calendars{day_periods}{$ctype}{$type}{$width}}) {
+                    foreach my $period (sort keys %{$calendars{day_periods}{$ctype}{$type}{$width}}) {
                         say $file "\t\t\t\t\t'$period' => q{$calendars{day_periods}{$ctype}{$type}{$width}{$period}},"
                     }
                     say $file "\t\t\t\t},";
@@ -3604,7 +3618,7 @@ has 'datetime_formats_available_formats' => (
 \tinit_arg\t=> undef,
 \tdefault\t\t=> sub { {
 EOT
-        foreach my $ctype (keys %{$calendars{datetime_formats}}) {
+        foreach my $ctype (sort keys %{$calendars{datetime_formats}}) {
 			if (exists $calendars{datetime_formats}{$ctype}{alias}) {
 				say $file "\t\t'$ctype' => {";
 				say $file "\t\t\t'alias' => q{$calendars{datetime_formats}{$ctype}{alias}},";
@@ -3631,7 +3645,7 @@ has 'datetime_formats_append_item' => (
 \tdefault\t\t=> sub { {
 EOT
 
-        foreach my $ctype (keys %{$calendars{datetime_formats}}) {
+        foreach my $ctype (sort keys %{$calendars{datetime_formats}}) {
 			if (exists $calendars{datetime_formats}{$ctype}{alias}) {
 				say $file "\t\t'$ctype' => {";
 				say $file "\t\t\t'alias' => q{$calendars{datetime_formats}{$ctype}{alias}},";
@@ -3658,7 +3672,7 @@ has 'datetime_formats_interval' => (
 \tdefault\t\t=> sub { {
 EOT
 
-        foreach my $ctype (keys %{$calendars{datetime_formats}}) {
+        foreach my $ctype (sort keys %{$calendars{datetime_formats}}) {
 			if (exists $calendars{datetime_formats}{$ctype}{alias}) {
 				say $file "\t\t'$ctype' => {";
 				say $file "\t\t\t'alias' => q{$calendars{datetime_formats}{$ctype}{alias}},";

--- a/Locale-CLDR/t/Ca/19-Currency.t
+++ b/Locale-CLDR/t/Ca/19-Currency.t
@@ -6,7 +6,7 @@ use warnings;
 use utf8;
 use if $^V ge v5.12.0, feature => 'unicode_strings';
 
-use Test::More tests => 25;
+use Test::More tests => 26;
 use Test::Exception;
 
 use ok 'Locale::CLDR';
@@ -46,3 +46,6 @@ is($locale->format_currency(123456.78), '123.456,78 £', 'Format currency with 
 is($locale->format_currency(123456.78, 'cash'), '123.456,78 £', 'Format currency with accountancy format, positive number and cash rounding and pound currency');
 is($locale->format_currency(-123456.78), '(123.456,78 £)', 'Format currency with accountancy format, negitive number and financial rounding and pound currency');
 is($locale->format_currency(-123456.78, 'cash'), '(123.456,78 £)', 'Format currency with accountancy format, negitive number and cash rounding and pound currency');
+
+$locale = Locale::CLDR->new(language_id => 'en', region_id => 'ca');
+is($locale->format_currency(1.03, 'cash'), 'CA$1.05', 'Low value cash rounding');

--- a/Locale-CLDR/t/Da/19-Currency.t
+++ b/Locale-CLDR/t/Da/19-Currency.t
@@ -22,9 +22,9 @@ is($locale->currency_format('accounting'), '#,##0.00 ¤', 'Accountcy currency f
 $locale = Locale::CLDR->new('da_DK_u_cf_standard');
 is($locale->currency_format(), '#,##0.00 ¤', 'Currency format with standard default');
 is($locale->format_currency(123456.78), '123.456,78 kr', 'Format currency with standard format, positive number and financial rounding');
-is($locale->format_currency(123456.78, 'cash'), '123.450,00 kr', 'Format currency with standard format, positive number and cash rounding');
+is($locale->format_currency(123456.78, 'cash'), '123.457,00 kr', 'Format currency with standard format, positive number and cash rounding');
 is($locale->format_currency(-123456.78), '-123.456,78 kr', 'Format currency with standard format, negitive number and financial rounding');
-is($locale->format_currency(-123456.78, 'cash'), '-123.450,00 kr', 'Format currency with standard format, negitive number and cash rounding');
+is($locale->format_currency(-123456.78, 'cash'), '-123.457,00 kr', 'Format currency with standard format, negitive number and cash rounding');
 
 $locale = Locale::CLDR->new('da_DK_u_cf_standard_cu_eur');
 is($locale->currency_format(), '#,##0.00 ¤', 'Currency format with standard default');
@@ -36,9 +36,9 @@ is($locale->format_currency(-123456.78, 'cash'), '-123.456,78 €', 'Format cur
 $locale = Locale::CLDR->new('da_DK_u_cf_account');
 is($locale->currency_format(), '#,##0.00 ¤', 'Currency format with account default');
 is($locale->format_currency(123456.78), '123.456,78 kr', 'Format currency with accountancy format, positive number and financial rounding');
-is($locale->format_currency(123456.78, 'cash'), '123.450,00 kr', 'Format currency with accountancy format, positive number and cash rounding');
+is($locale->format_currency(123456.78, 'cash'), '123.457,00 kr', 'Format currency with accountancy format, positive number and cash rounding');
 is($locale->format_currency(-123456.78), '-123.456,78 kr', 'Format currency with accountancy format, negitive number and financial rounding');
-is($locale->format_currency(-123456.78, 'cash'), '-123.450,00 kr', 'Format currency with accountancy format, negitive number and cash rounding');
+is($locale->format_currency(-123456.78, 'cash'), '-123.457,00 kr', 'Format currency with accountancy format, negitive number and cash rounding');
 
 $locale = Locale::CLDR->new('da_DK_u_cf_account_cu_eur');
 is($locale->currency_format(), '#,##0.00 ¤', 'Currency format with account default');


### PR DESCRIPTION
Hi,

This was a minor release, only for the bugfixes submitted for v0.34.

I was not comfortable enough to do a CLDR update. Later versions add more variables and the generated code doesn't compile.

v35 and later also seem to change condition logic, and I didn't have time or experience to change the code generation and validate that the result was valid.

The fixes in this release are:
    Fixed for-cash rounding problem
    Fix warning in plural rules where fraction is used
    Fix typo in POD documentation

Besides that, it adds more 'sort's to loops on keys, and redoes the sort on day_period_type, to make the code generation fully deterministic, so diffs between versions are limited to actual logic changes.