### PR TITLE
Print contents of the bundle as separate lines (paragraphs)

### DIFF
--- a/Locale-CLDR/mkcldr.pl
+++ b/Locale-CLDR/mkcldr.pl
@@ -5483,7 +5483,7 @@ EOT
         # Only put En and Root in the base bundle
         next if $name ne 'Base' && $package eq 'Locale::CLDR::Locales::Root';
         next if $name ne 'Base' && $package eq 'Locale::CLDR::Locales::En';
-        say $file "$package $VERSION" ;
+        print $file "$package $VERSION\n\n" ;
     }
 
     print $file <<EOT;


### PR DESCRIPTION
This patch improves readability of the generated output of the region bundle files. 

Without this patch, the CONTENTS section of the POD renders as a line wrapped paragraph containing a sequence of module names alternating with version numbers. See https://metacpan.org/release/JGNI/Bundle-Locale-CLDR-Easterneurope-0.34.2/view/lib/Bundle/Locale/CLDR/Easterneurope.pm as a case of reference.