### PR TITLE
remove dependency on List::MoreUtils

### DIFF
--- a/Locale-CLDR/mkcldr.pl
+++ b/Locale-CLDR/mkcldr.pl
@@ -27,8 +27,7 @@ use Archive::Extract;
 use DateTime;
 use XML::Parser;
 use Text::ParseWords;
-use List::MoreUtils qw( any );
-use List::Util qw( min max uniq);
+use List::Util qw( any min max uniq);
 use Unicode::Regex::Set();
 
 use lib "${FindBin::Bin}/lib";
@@ -6010,7 +6009,6 @@ my \$builder = Module::Build->new(
         'DateTime::Locale'          => 0,
         'namespace::autoclean'      => '0.16',
         'List::Util'                => '1.45',
-        'List::MoreUtils'           => 0,
         'Unicode::Regex::Set'       => 0,
         'bigfloat'                  => 0,
     },


### PR DESCRIPTION
The builder script is using `List::MoreUtils`, but only for `any` which is available from `List::Util` 1.33.  I don't think the generated `.pm` files actually use it anymore.